### PR TITLE
CloudWatch billing alarm and sample CFN template

### DIFF
--- a/module_4.3/README.md
+++ b/module_4.3/README.md
@@ -1,0 +1,19 @@
+The lab in 4.3 goes over how to create a billing alarm.
+This file will contains any notes I take on the process
+
+Billing Alarm - will send you an alert when your bill for the month goes over a set amount.
+
+1. Go to CloudWatch in the console
+2. Go to billing
+3. Create alarm
+
+Period is how often the system will check the cost.
+4. Createe a new SNS topic: throw in a legitimate email address, click create
+5. Go to your email to subscribe to the topic
+6. Next in the console, name the alarm and put in a description
+
+Pending confirmation means you have not gone to your meail yet.
+After confirming, you can can go back to the console, hit refresh and the message should change.
+
+CERT:
+If the exam asks how you can get automatic notifcations if the account goes over a cost threshold, the answer will have to do with creating a billing alarm.

--- a/module_4.3/templates/billing_alarm_sample.md
+++ b/module_4.3/templates/billing_alarm_sample.md
@@ -1,0 +1,4 @@
+FILE: billing_alarm_sample.yaml
+PURPOSE: An example of a Cloudformation template that could be used to create a CloudWatch billing alarm. 
+NOTES: Probably silly to create a stack with just this resource. Would be better served as part of a larger template
+The Parameters can be stored/managed from a separate JSON file like an CFN template

--- a/module_4.3/templates/billing_alarm_sample.yaml
+++ b/module_4.3/templates/billing_alarm_sample.yaml
@@ -1,0 +1,35 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Description: 'Billing Alarm Sample'
+
+Parameters:
+  AlarmThreshold:
+    Type: string
+    Default: "50"
+  BillingAlarmNotification:
+    Type: string
+    Default: "Cost threshold has been reached"
+
+Resources:
+  SpendingAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmDescription:
+        'Fn::Join':
+          - ''
+          - - Alarm if AWS spending is over $
+            - Ref: AlarmThresholdl
+      Namespace: AWS/Billing
+      MetricName: EstimatedCharges
+      Dimensions:
+        - Name: Currency
+          Value: USD
+      Statistic: Maximum
+      Period: '21600'
+      EvaluationPeriods: '1'
+      Threshold:
+        Ref: AlarmThreshold
+      ComparisonOperator: GreaterThanThreshold
+      AlarmActions:
+      - Ref: BillingAlarmNotification
+      InsufficientDataActions:
+      - Ref: BillingAlarmNotification


### PR DESCRIPTION
Basic notes from going through the ACG module and a CFN template example derived from AWS documentation: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/quickref-cloudwatch.html